### PR TITLE
Add g++-multilib to fix arm builds

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,3 +64,4 @@ parts:
       snap/lightsoff/current/usr: usr
     build-packages:
       - libclutter-gtk-1.0-dev
+      - g++-multilib


### PR DESCRIPTION
## Description

Added `g++-multilib` to the build packages to fix builds on arm64.

## Type of change

Please check only the options that are relevant.

- [x] General maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

