### PR TITLE
Add correct build-dep for arm64

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,3 +64,6 @@ parts:
       snap/lightsoff/current/usr: usr
     build-packages:
       - libclutter-gtk-1.0-dev
+      - on amd64:
+        - gcc-multilib
+        - g++-multilib


### PR DESCRIPTION
## Description

It turns out that `g++-multilib` is not the right package name but rather we need`g++-multilib-arm-linux-gnueabi` to fix the arm64 build. see https://launchpadlibrarian.net/573877169/buildlog_snap_ubuntu_focal_arm64_lightsoff_BUILDING.txt.gz

## Type of change

Please check only the options that are relevant.

- [x] General maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

